### PR TITLE
Keep existing team data on install

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -225,15 +225,16 @@ class Client {
       console.log(`Authorizing ${auth.authed_user.id}`);
       return this.store
         .get(auth.authed_user.id)
-        .then((existingUser) => ({...existingUser, ...auth}));
+        .then((existingUser) => ({ ...existingUser, ...auth }));
     }
     return this.send('auth.test', { token: auth.access_token })
-      .then(data => {
-        auth.url = data.url;
-        return this.store
-          .get(auth.team.id)
-          .then((existingTeam) => ({ ...existingTeam, ...auth }));
-      });
+      .then(({ url }) => this.store
+        .get(auth.team.id)
+        .then((existingTeam) => ({
+          ...existingTeam,
+          ...auth,
+          url,
+        })));
   }
 
 

--- a/src/client.js
+++ b/src/client.js
@@ -223,14 +223,17 @@ class Client {
     console.log(JSON.stringify(auth));
     if (!auth.access_token) {
       console.log(`Authorizing ${auth.authed_user.id}`);
-      return this.store.get(auth.authed_user.id).then((existingUser) => (
-        {...existingUser, ...auth}
-      ));
+      return this.store
+        .get(auth.authed_user.id)
+        .then((existingUser) => ({...existingUser, ...auth}));
     }
-    return this.send('auth.test', { token: auth.access_token }).then(data => {
-      auth.url = data.url;
-      return Promise.resolve(auth);
-    });
+    return this.send('auth.test', { token: auth.access_token })
+      .then(data => {
+        auth.url = data.url;
+        return this.store
+          .get(auth.team.id)
+          .then((existingTeam) => ({ ...existingTeam, ...auth }));
+      });
   }
 
 


### PR DESCRIPTION
- Keep existing team data when handling bot install events.
- Return all existing data if a team record exists.